### PR TITLE
prefer preprocessor macro over hardcoded file names

### DIFF
--- a/src/GasDiffusion.C
+++ b/src/GasDiffusion.C
@@ -100,7 +100,7 @@ void GasDiffusion()
 	}
 
 	default:
-		ErrorMessages::Switch("GasDiffusion.cpp", "iDiffusionSolver", int(input_variable[iv["iDiffusionSolver"]].getValue()));
+		ErrorMessages::Switch(__FILE__, "iDiffusionSolver", int(input_variable[iv["iDiffusionSolver"]].getValue()));
 		break;
 	}
 }

--- a/src/GrainBoundarySweeping.C
+++ b/src/GrainBoundarySweeping.C
@@ -59,7 +59,7 @@ void GrainBoundarySweeping()
 	}
 
 	default:
-		ErrorMessages::Switch("GrainBoundarySweeping.cpp", "iGrainBoundarySweeping", int(input_variable[iv["iGrainBoundarySweeping"]].getValue()));
+		ErrorMessages::Switch(__FILE__, "iGrainBoundarySweeping", int(input_variable[iv["iGrainBoundarySweeping"]].getValue()));
 		break;
 	}
 }

--- a/src/GrainBoundaryVenting.C
+++ b/src/GrainBoundaryVenting.C
@@ -67,7 +67,7 @@ void GrainBoundaryVenting()
 	}
 
 	default:
-		ErrorMessages::Switch("GrainBoundaryVenting.cpp", "iGrainBoundaryVenting", int(input_variable[iv["iGrainBoundaryVenting"]].getValue()));
+		ErrorMessages::Switch(__FILE__, "iGrainBoundaryVenting", int(input_variable[iv["iGrainBoundaryVenting"]].getValue()));
 		break;
 	}
 

--- a/src/GrainGrowth.C
+++ b/src/GrainGrowth.C
@@ -138,7 +138,7 @@ void GrainGrowth()
 	}
 
 	default:
-		ErrorMessages::Switch("GrainGrowth.cpp", "iGrainGrowth", int(input_variable[iv["iGrainGrowth"]].getValue()));
+		ErrorMessages::Switch(__FILE__, "iGrainGrowth", int(input_variable[iv["iGrainGrowth"]].getValue()));
 		break;
 	}
 	model[model_index].setParameter(parameter);

--- a/src/HighBurnupStructureFormation.C
+++ b/src/HighBurnupStructureFormation.C
@@ -78,7 +78,7 @@ void HighBurnupStructureFormation()
 	}
 
 	default:
-		ErrorMessages::Switch("HighBurnupStructureFormation.cpp", "iHighBurnupStructureFormation", int(input_variable[iv["iHighBurnupStructureFormation"]].getValue()));
+		ErrorMessages::Switch(__FILE__, "iHighBurnupStructureFormation", int(input_variable[iv["iHighBurnupStructureFormation"]].getValue()));
 		break;
 	}
 

--- a/src/HighBurnupStructurePorosity.C
+++ b/src/HighBurnupStructurePorosity.C
@@ -74,7 +74,7 @@ void HighBurnupStructurePorosity()
 	}
 
 	default:
-		ErrorMessages::Switch("HighBurnupStructurePorosity.cpp", "HighBurnupStructurePorosity", int(input_variable[iv["HighBurnupStructurePorosity"]].getValue()));
+		ErrorMessages::Switch(__FILE__, "HighBurnupStructurePorosity", int(input_variable[iv["HighBurnupStructurePorosity"]].getValue()));
 		break;
 	}
 

--- a/src/IntraGranularBubbleEvolution.C
+++ b/src/IntraGranularBubbleEvolution.C
@@ -146,7 +146,7 @@ void IntraGranularBubbleEvolution()
 	}
 
 	default:
-		ErrorMessages::Switch("IntraGranularBubbleEvolution.cpp", "iIntraGranularBubbleEvolution", int(input_variable[iv["iIntraGranularBubbleEvolution"]].getValue()));
+		ErrorMessages::Switch(__FILE__, "iIntraGranularBubbleEvolution", int(input_variable[iv["iIntraGranularBubbleEvolution"]].getValue()));
 		break;
 	}
 

--- a/src/SetMatrix.C
+++ b/src/SetMatrix.C
@@ -42,7 +42,7 @@ void SetMatrix( )
 		}
 		
 		default:
-			ErrorMessages::Switch("SetMatrix.cpp", "iFuelMatrix", int(input_variable[iv["iFuelMatrix"]].getValue()));
+			ErrorMessages::Switch(__FILE__, "iFuelMatrix", int(input_variable[iv["iFuelMatrix"]].getValue()));
 			break;
 	}
 }
@@ -88,7 +88,7 @@ void Matrix::setGrainBoundaryMobility(int input_value)
 	}
 
 	default:
-		ErrorMessages::Switch("SetMatrix.cpp", "iGrainGrowth", input_value);
+		ErrorMessages::Switch(__FILE__, "iGrainGrowth", input_value);
 		break;
 	}
 }
@@ -161,7 +161,7 @@ void Matrix::setGrainBoundaryVacancyDiffusivity(int input_value)
 		}
 
 		default:
-			ErrorMessages::Switch("SetMatrix.cpp", "iGrainBoundaryVacancyDiffusivity", input_value);
+			ErrorMessages::Switch(__FILE__, "iGrainBoundaryVacancyDiffusivity", input_value);
 			break;
 			
 	}

--- a/src/SetSystem.C
+++ b/src/SetSystem.C
@@ -90,7 +90,7 @@ void System::setBubbleDiffusivity(int input_value)
 		}
 
 		default:
-			ErrorMessages::Switch("SetSystem.cpp", "iBubbleDiffusivity", input_value);
+			ErrorMessages::Switch(__FILE__, "iBubbleDiffusivity", input_value);
 			break;
 	}
 
@@ -263,7 +263,7 @@ void System::setFissionGasDiffusivity(int input_value)
 	}
 
 	default:
-		ErrorMessages::Switch("SetSystem.cpp", "iFGDiffusionCoefficient", input_value);
+		ErrorMessages::Switch(__FILE__, "iFGDiffusionCoefficient", input_value);
 		break;
 	}
 }
@@ -344,7 +344,7 @@ void System::setHeliumDiffusivity(int input_value)
 	}
 
 	default:
-		ErrorMessages::Switch("SetSystem.cpp", "iHeDiffusivity", input_value);
+		ErrorMessages::Switch(__FILE__, "iHeDiffusivity", input_value);
 		break;
 	}
 }
@@ -459,7 +459,7 @@ void System::setResolutionRate(int input_value)
 	}
 
 	default:
-		ErrorMessages::Switch("SetSystem.cpp", "iResolutionRate", input_value);
+		ErrorMessages::Switch(__FILE__, "iResolutionRate", input_value);
 		break;
 	}
 	resolution_rate *= sf_resolution_rate;
@@ -531,7 +531,7 @@ void System::setTrappingRate(int input_value)
 	}
 
 	default:
-		ErrorMessages::Switch("SetSystem.cpp", "iTrappingRate", input_value);
+		ErrorMessages::Switch(__FILE__, "iTrappingRate", input_value);
 		break;
 	}
 }
@@ -588,7 +588,7 @@ void System::setNucleationRate(int input_value)
 	}
 
 	default:
-		ErrorMessages::Switch("SetSystem.cpp", "inucleation_rate", input_value);
+		ErrorMessages::Switch(__FILE__, "inucleation_rate", input_value);
 		break;
 	}
 }
@@ -667,7 +667,7 @@ void System::setProductionRate(int input_value)
 	}
 
 	default:
-		ErrorMessages::Switch("SetSystem.cpp", "iHeliumProductionRate", input_value);
+		ErrorMessages::Switch(__FILE__, "iHeliumProductionRate", input_value);
 		break;
 	}
 

--- a/src/StoichiometryDeviation.C
+++ b/src/StoichiometryDeviation.C
@@ -309,7 +309,7 @@ void StoichiometryDeviation()
 
     
     default :
-      ErrorMessages::Switch("StoichiometryDeviation.cpp", "iStoichiometryDeviation", int(input_variable[iv["iStoichiometryDeviation"]].getValue()));
+      ErrorMessages::Switch(__FILE__, "iStoichiometryDeviation", int(input_variable[iv["iStoichiometryDeviation"]].getValue()));
       break;
   }
 }


### PR DESCRIPTION
Closes #17 by using preprocessor macro `__FILE__`. The respective error message would become 
```
Error in src/SetSystem.C.
The input setting iFGDiffusionCoefficient = 273 is out of range.
```
Also, it is now robust against code file name changes. 

Alternative approach would be using the `std::source_location` structure as explained in [StackOverflow](https://stackoverflow.com/a/58556021/13224210), however, I do not want to limit the C++ standard, since that is only in C++20 and newer.