### PR TITLE
Sort references

### DIFF
--- a/references/references.md
+++ b/references/references.md
@@ -1,58 +1,65 @@
 # References {#references}
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311594902011" target="_blank">Abrefah H. et al (1994). Journal of Nuclear Materials, 208, 98-110.</a>
+## Models
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311573900019" target="_blank">Ainscough J.B. et al (1973). Journal of Nuclear Materials, 49, 117-128.</a>
+## Validation
 
-<a href="https://www.sciencedirect.com/science/article/pii/S002231152030427X" target="_blank">Barani T. et al (2020). Journal of Nuclear Materials, 539, 152296.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311522001234" target="_blank">Barani T. et al (2022). Journal of Nuclear Materials, 563, 153627.</a>
 
-<a href="https://doi.org/10.1111/j.1151-2916.1969.tb11976.x" target="_blank">Bittel R. et al (1969). Journal of the American Ceramic Society, 52, 446-451.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/002231157390038X" target="_blank">Blackburn P.E. (1973). Journal of Nuclear Materials, 46, 244-252.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311594902011" target="_blank">Abrefah H. et al (1994). High temperature oxidation of UO2 in steam-hydrogen mixtures. Journal of Nuclear Materials, 208, 98-110.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311570900632" target="_blank">Carter G. and Lay G.R. (1970). Journal of Nuclear Materials, 36, 77-86.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311573900019" target="_blank">Ainscough J.B. et al (1973). Isothermal grain growth kinetics in sintered UO2 pellets. Journal of Nuclear Materials, 49, 117-128.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S1738573320309451" target="_blank">Cechet A. et al (2021). Nuclear Engineering and Technology, 53, 1893-1908.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S002231152030427X" target="_blank">Barani T. et al (2020). Modeling high burnup structure in oxide fuels for application to fuel performance codes. part I: High burnup structure formation. Journal of Nuclear Materials, 539, 152296.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0029549318304606" target="_blank">Cognini L. et al (2018). Nuclear Engineering and Design, 340, 240-244.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311522001234" target="_blank">Barani T. et al (2022). Modeling high burnup structure in oxide fuels for application to fuel performance codes. Part II: Porosity evolution. Journal of Nuclear Materials, 563, 153627.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S1738573320303557" target="_blank">Cognini L. et al (2021). Nuclear Engineering and Technology, 53, 562-571.</a>
+<a href="https://doi.org/10.1111/j.1151-2916.1969.tb11976.x" target="_blank">Bittel R. et al (1969). Steam Oxidation Kinetics and Oxygen Diffusion in UOz at High Temperatures. Journal of the American Ceramic Society, 52, 446-451.</a>
 
-<a href="https://inis.iaea.org/search/search.aspx?orig_q=RN:21045512" target="_blank">Cox B. et al (1986). NUREG/CP-0078, U.S. NRC.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/002231157390038X" target="_blank">Blackburn P.E. (1973). Oxygen pressures over fast breeder reactor fuel (I) A model for UO2+-x. Journal of Nuclear Materials, 46, 244-252.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311594902186" target="_blank">Evans J.H. (1994). Journal of Nuclear Materials, 210, 21-29.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311570900632" target="_blank">Carter G. and Lay G.R. (1970). Surface-controlled oxidation-reduction of UO2. Journal of Nuclear Materials, 36, 77-86.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022369758900532" target="_blank">Ham F.S. (1958). Journal of Physics and Chemistry of Solids, 6, 335-351.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S1738573320309451" target="_blank">Cechet A. et al (2021). A new burn-up module for application in fuel performance calculations targeting the helium production rate in (U,Pu)O2 for fast reactors. Nuclear Engineering and Technology, 53, 1893-1908.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311597000822" target="_blank">Imamura M. and Une K. (1997). Journal of Nuclear Materials, 247, 131-137.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S0029549318304606" target="_blank">Cognini L. et al (2018). Helium solubility in oxide nuclear fuel: Derivation of new correlations for Henry’s constant. Nuclear Engineering and Design, 340, 240-244.</a>
 
-<a href="https://www.researchgate.net/publication/272095903_Approaches_to_Modeling_of_High_Burn-up_Structure_and_Analysis_of_its_Effects_on_the_Behaviour_of_Light_Water_Reactor_Fuels_in_the_START-3_Fuel_Performance_Code" target="_blank">Khvostov G. et al (2005). WRFPM-2005, Kyoto, Japan.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S1738573320303557" target="_blank">Cognini L. et al (2021). Towards a physics-based description of intra-granular helium behaviour in oxide fuel for application in fuel performance codes. Nuclear Engineering and Technology, 53, 562-571.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311595001301" target="_blank">Lewis B.J. et al (1995). Journal of Nuclear Materials, 227, 83-109.</a>
+<a href="https://inis.iaea.org/search/search.aspx?orig_q=RN:21045512" target="_blank">Cox B. et al (1986). Oxidation of UO2 in air and steam with relevance to fission product releases. NUREG/CP-0078, U.S. NRC.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311502008565" target="_blank">Losonen P. (2002). Journal of Nuclear Materials, 304, 29-49.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311594902186" target="_blank">Evans J.H. (1994). Bubble diffusion to grain boundaries in UO2 and metals during annealing: a new approach. Journal of Nuclear Materials, 210, 21-29.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0029549318300578" target="_blank">Luzzi L. et al (2018). Nuclear Engineering and Design, 330, 265-271.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022369758900532" target="_blank">Ham F.S. (1958). Theory of diffusion-limited precipitation. Journal of Physics and Chemistry of Solids, 6, 335-351.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311597000822" target="_blank">Imamura M. and Une K. (1997). High temperature steam oxidation of U02 fuel pellets. Journal of Nuclear Materials, 247, 131-137.</a>
+
+<a href="https://www.researchgate.net/publication/272095903_Approaches_to_Modeling_of_High_Burn-up_Structure_and_Analysis_of_its_Effects_on_the_Behaviour_of_Light_Water_Reactor_Fuels_in_the_START-3_Fuel_Performance_Code" target="_blank">Khvostov G. et al (2005). Approaches to Modeling of High Burn-up Structure and Analysis of its Effects on the Behaviour of Light Water Reactor Fuels in the START-3 Fuel Performance Code. WRFPM-2005, Kyoto, Japan.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311595001301" target="_blank">Lewis B.J. et al (1995). Modelling the release behaviour of cesium during severe fuel degradation. Journal of Nuclear Materials, 227, 83-109.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311502008565" target="_blank">Lösönen P. (2002). Modelling intragranular fission gas release in irradiation of sintered LWR UO2 fuel. Journal of Nuclear Materials, 304, 29-49.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0029549318300578" target="_blank">Luzzi L. et al (2018). Helium diffusivity in oxide nuclear fuel: Critical data analysis and new correlations. Nuclear Engineering and Design, 330, 265-271.</a>
 
 <a href="https://www.stralsakerhetsmyndigheten.se/en/publications/reports/safety-at-nuclear-power-plants/2018/201825/" target="_blank">Massih A.R. (2018). UO2 Fuel Oxidation and Fission Gas Release, Swedish Radiation Safety Authority (SSM).</a>
 
-<a href="https://www.tandfonline.com/doi/abs/10.1080/00337578008207118" target="_blank">Matzke H. (1980). Radiation Effects, 53, 219-242.</a>
+<a href="https://www.tandfonline.com/doi/abs/10.1080/00337578008207118" target="_blank">Matzke H. (1980). Gas release mechanisms in UO2—a critical review. Radiation Effects, 53, 219-242.</a>
 
 <a> Morel B., Serose N., Gamaury S., Ph. Dehaudt, "Cinetique d'Oxydation du Combustible par la Vapeur d'Eau; Influence du S/V," Commissariat a l'Energie Atomique, Report NT/DTP/SECC no. DR94-55, June 1994..</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S002231150600198X" target="_blank">Olander D.R. and Wongsawaeng D. (2006). Journal of Nuclear Materials, 354, 94-109.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S002231150600198X" target="_blank">Olander D.R. and Wongsawaeng D. (2006). Re-solution of fission gas – A review: Part I. Intragranular bubbles. Journal of Nuclear Materials, 354, 94-109.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029549312005754" target="_blank">Pastore G. et al (2013). Nuclear Engineering and Design, 256, 75-86.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029549312005754" target="_blank">Pastore G. et al (2013). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Nuclear Engineering and Design, 256, 75-86.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311517315039" target="_blank">Pizzocri D. et al (2018). Journal of Nuclear Materials, 502, 323-330.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311517315039" target="_blank">Pizzocri D. et al (2018). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Journal of Nuclear Materials, 502, 323-330.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311519313868" target="_blank">Pizzocri D. et al (2020). Journal of Nuclear Materials, 532, 152042.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311519313868" target="_blank">Pizzocri D. et al (2020). SCIANTIX: A new open source multi-scale code for fission gas behaviour modelling designed for nuclear fuel performance codes. Journal of Nuclear Materials, 532, 152042.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311579900357" target="_blank">Reynolds A.B. and Burton C. (1979). Journal of Nuclear Materials, 82, 22-25.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311579900357" target="_blank">Reynolds A.B. and Burton C. (1979). Grain-boundary diffusion in uranium dioxide: The correlation between sintering and creep and a reinterpretation of creep mechanism. Journal of Nuclear Materials, 82, 22-25.</a>
 
-<a href="https://link.springer.com/article/10.1134/S0018151X07040177" target="_blank">Ronchi C. (2007). High Temperatures, 45, 552-571.</a>
+<a href="https://link.springer.com/article/10.1134/S0018151X07040177" target="_blank">Ronchi C. (2007). Thermophysical properties affecting safety and performance of nuclear fuel. High Temperatures, 45, 552-571.</a>
 
 <a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311513012336" target="_blank">Talip Z. et al (2014). Journal of Nuclear Materials, 445, 117-127.</a>
 
@@ -72,7 +79,7 @@
 
 <a href="https://www.sciencedirect.com/science/article/pii/S0022311523005111" target="_blank">Zullo G. et al (2023). Journal of Nuclear Materials, 587, 154744.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311524004070" target="_blank">Zullo G. et al (2024). Journal of Nuclear Materials, 601, 155305.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311524004070" target="_blank">Zullo G. et al (2024). Integral-scale validation of the SCIANTIX code for Light Water Reactor fuel rods Journal of Nuclear Materials, 601, 155305.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0029549324007027" target="_blank">Zullo G. et al (2024). Nuclear Enginnering and Design, 429, 113602.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S0029549324007027" target="_blank">Zullo G. et al (2024). Two-phase modelling for fission gas sweeping in restructuring nuclear oxide fuel. Nuclear Enginnering and Design, 429, 113602.</a>
 

--- a/references/references.md
+++ b/references/references.md
@@ -1,31 +1,99 @@
 # References {#references}
 
-## Models
+
+## SCIANTIX papers
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311523005111" target="_blank">Zullo G. et al (2023). The SCIANTIX code for fission gas behaviour: Status, upgrades, separate-effect validation, and future developments. Journal of Nuclear Materials, 587, 154744.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311519313868" target="_blank">Pizzocri D. et al (2020). SCIANTIX: A new open source multi-scale code for fission gas behaviour modelling designed for nuclear fuel performance codes. Journal of Nuclear Materials, 532, 152042.</a>
+
+
 
 ## Validation
 
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311524004070" target="_blank">Zullo G. et al (2024). Integral-scale validation of the SCIANTIX code for Light Water Reactor fuel rods Journal of Nuclear Materials, 601, 155305.</a>
 
 
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311594902011" target="_blank">Abrefah H. et al (1994). High temperature oxidation of UO2 in steam-hydrogen mixtures. Journal of Nuclear Materials, 208, 98-110.</a>
-
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311573900019" target="_blank">Ainscough J.B. et al (1973). Isothermal grain growth kinetics in sintered UO2 pellets. Journal of Nuclear Materials, 49, 117-128.</a>
+## Models
 
 <a href="https://www.sciencedirect.com/science/article/pii/S002231152030427X" target="_blank">Barani T. et al (2020). Modeling high burnup structure in oxide fuels for application to fuel performance codes. part I: High burnup structure formation. Journal of Nuclear Materials, 539, 152296.</a>
 
 <a href="https://www.sciencedirect.com/science/article/pii/S0022311522001234" target="_blank">Barani T. et al (2022). Modeling high burnup structure in oxide fuels for application to fuel performance codes. Part II: Porosity evolution. Journal of Nuclear Materials, 563, 153627.</a>
 
-<a href="https://doi.org/10.1111/j.1151-2916.1969.tb11976.x" target="_blank">Bittel R. et al (1969). Steam Oxidation Kinetics and Oxygen Diffusion in UOz at High Temperatures. Journal of the American Ceramic Society, 52, 446-451.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311583901769" target="_blank">White R.M. and Tucker P.G. (1983). A new fission-gas release model. Journal of Nuclear Materials, 118, 1-38.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0029549324007027" target="_blank">Zullo G. et al (2024). Two-phase modelling for fission gas sweeping in restructuring nuclear oxide fuel. Nuclear Enginnering and Design, 429, 113602.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029549312005754" target="_blank">Pastore G. et al (2013). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Nuclear Engineering and Design, 256, 75-86.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311517315039" target="_blank">Pizzocri D. et al (2018). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Journal of Nuclear Materials, 502, 323-330.</a>
 
 <a href="https://www.sciencedirect.com/science/article/abs/pii/002231157390038X" target="_blank">Blackburn P.E. (1973). Oxygen pressures over fast breeder reactor fuel (I) A model for UO2+-x. Journal of Nuclear Materials, 46, 244-252.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311570900632" target="_blank">Carter G. and Lay G.R. (1970). Surface-controlled oxidation-reduction of UO2. Journal of Nuclear Materials, 36, 77-86.</a>
+<a href="https://www.researchgate.net/publication/272095903_Approaches_to_Modeling_of_High_Burn-up_Structure_and_Analysis_of_its_Effects_on_the_Behaviour_of_Light_Water_Reactor_Fuels_in_the_START-3_Fuel_Performance_Code" target="_blank">Khvostov G. et al (2005). Approaches to Modeling of High Burn-up Structure and Analysis of its Effects on the Behaviour of Light Water Reactor Fuels in the START-3 Fuel Performance Code. WRFPM-2005, Kyoto, Japan.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311595001301" target="_blank">Lewis B.J. et al (1995). Modelling the release behaviour of cesium during severe fuel degradation. Journal of Nuclear Materials, 227, 83-109.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311502008565" target="_blank">Lösönen P. (2002). Modelling intragranular fission gas release in irradiation of sintered LWR UO2 fuel. Journal of Nuclear Materials, 304, 29-49.</a>
+
+<a href="https://www.nrc.gov/reading-rm/doc-collections/nuregs/contract/cr7003/index.html" target="_blank">Turnbull J.A., Beyer C.E. (2010). Background and Derivation of ANS-5.4 Standard Fission Product Release Model.</a>
 
 <a href="https://www.sciencedirect.com/science/article/pii/S1738573320309451" target="_blank">Cechet A. et al (2021). A new burn-up module for application in fuel performance calculations targeting the helium production rate in (U,Pu)O2 for fast reactors. Nuclear Engineering and Technology, 53, 1893-1908.</a>
 
+<a href="https://www.sciencedirect.com/science/article/pii/S1738573320303557" target="_blank">Cognini L. et al (2021). Towards a physics-based description of intra-granular helium behaviour in oxide fuel for application in fuel performance codes. Nuclear Engineering and Technology, 53, 562-571.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311503004616" target="_blank">White R.M. (2004). The development of grain-face porosity in irradiated oxide fuel. Journal of Nuclear Materials, 325, 61-77.</a>
+
+
+
+
+
+## Experiments
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311594902011" target="_blank">Abrefah H. et al (1994). High temperature oxidation of UO2 in steam-hydrogen mixtures. Journal of Nuclear Materials, 208, 98-110.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311573900019" target="_blank">Ainscough J.B. et al (1973). Isothermal grain growth kinetics in sintered UO2 pellets. Journal of Nuclear Materials, 49, 117-128.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311570900632" target="_blank">Carter G. and Lay G.R. (1970). Surface-controlled oxidation-reduction of UO2. Journal of Nuclear Materials, 36, 77-86.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311512006526" target="_blank">Van Uffelen P. et al (2013). An experimental study of grain growth in mixed oxide samples with various microstructures and plutonium concentrations. Journal of Nuclear Materials, 434, 287-290.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311513012336" target="_blank">Talip Z. et al (2014). Thermal diffusion of helium in 238Pu-doped UO2. Journal of Nuclear Materials, 445, 117-127.</a>
+
+
+
+
+
+## Correlations
+
 <a href="https://www.sciencedirect.com/science/article/pii/S0029549318304606" target="_blank">Cognini L. et al (2018). Helium solubility in oxide nuclear fuel: Derivation of new correlations for Henry’s constant. Nuclear Engineering and Design, 340, 240-244.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S1738573320303557" target="_blank">Cognini L. et al (2021). Towards a physics-based description of intra-granular helium behaviour in oxide fuel for application in fuel performance codes. Nuclear Engineering and Technology, 53, 562-571.</a>
+<a href="https://www.sciencedirect.com/science/article/pii/S0029549318300578" target="_blank">Luzzi L. et al (2018). Helium diffusivity in oxide nuclear fuel: Critical data analysis and new correlations. Nuclear Engineering and Design, 330, 265-271.</a>
+
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311579900357" target="_blank">Reynolds A.B. and Burton C. (1979). Grain-boundary diffusion in uranium dioxide: The correlation between sintering and creep and a reinterpretation of creep mechanism. Journal of Nuclear Materials, 82, 22-25.</a>
+
+<a href="https://doi.org/10.1111/j.1151-2916.1969.tb11976.x" target="_blank">Bittel R. et al (1969). Steam Oxidation Kinetics and Oxygen Diffusion in UOz at High Temperatures. Journal of the American Ceramic Society, 52, 446-451.</a>
+
+
+
+
+
+
+
+## Reviews
+
+<a href="https://www.tandfonline.com/doi/abs/10.1080/00337578008207118" target="_blank">Matzke H. (1980). Gas release mechanisms in UO2—a critical review. Radiation Effects, 53, 219-242.</a>
+
+
+## Algorithms
+
+<a href="https://www.sciencedirect.com/science/article/pii/S1738573321006148" target="_blank">Zullo G. et al (2022). On the use of spectral algorithms for the prediction of short-lived volatile fission product release: Methodology for bounding numerical error. Nuclear Engineering and Technology, 54, 1195-1205.</a>
+
+
+
+## Other
+
 
 <a href="https://inis.iaea.org/search/search.aspx?orig_q=RN:21045512" target="_blank">Cox B. et al (1986). Oxidation of UO2 in air and steam with relevance to fission product releases. NUREG/CP-0078, U.S. NRC.</a>
 
@@ -35,51 +103,19 @@
 
 <a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311597000822" target="_blank">Imamura M. and Une K. (1997). High temperature steam oxidation of U02 fuel pellets. Journal of Nuclear Materials, 247, 131-137.</a>
 
-<a href="https://www.researchgate.net/publication/272095903_Approaches_to_Modeling_of_High_Burn-up_Structure_and_Analysis_of_its_Effects_on_the_Behaviour_of_Light_Water_Reactor_Fuels_in_the_START-3_Fuel_Performance_Code" target="_blank">Khvostov G. et al (2005). Approaches to Modeling of High Burn-up Structure and Analysis of its Effects on the Behaviour of Light Water Reactor Fuels in the START-3 Fuel Performance Code. WRFPM-2005, Kyoto, Japan.</a>
-
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311595001301" target="_blank">Lewis B.J. et al (1995). Modelling the release behaviour of cesium during severe fuel degradation. Journal of Nuclear Materials, 227, 83-109.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311502008565" target="_blank">Lösönen P. (2002). Modelling intragranular fission gas release in irradiation of sintered LWR UO2 fuel. Journal of Nuclear Materials, 304, 29-49.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0029549318300578" target="_blank">Luzzi L. et al (2018). Helium diffusivity in oxide nuclear fuel: Critical data analysis and new correlations. Nuclear Engineering and Design, 330, 265-271.</a>
 
 <a href="https://www.stralsakerhetsmyndigheten.se/en/publications/reports/safety-at-nuclear-power-plants/2018/201825/" target="_blank">Massih A.R. (2018). UO2 Fuel Oxidation and Fission Gas Release, Swedish Radiation Safety Authority (SSM).</a>
 
-<a href="https://www.tandfonline.com/doi/abs/10.1080/00337578008207118" target="_blank">Matzke H. (1980). Gas release mechanisms in UO2—a critical review. Radiation Effects, 53, 219-242.</a>
 
 <a> Morel B., Serose N., Gamaury S., Ph. Dehaudt, "Cinetique d'Oxydation du Combustible par la Vapeur d'Eau; Influence du S/V," Commissariat a l'Energie Atomique, Report NT/DTP/SECC no. DR94-55, June 1994..</a>
 
 <a href="https://www.sciencedirect.com/science/article/pii/S002231150600198X" target="_blank">Olander D.R. and Wongsawaeng D. (2006). Re-solution of fission gas – A review: Part I. Intragranular bubbles. Journal of Nuclear Materials, 354, 94-109.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029549312005754" target="_blank">Pastore G. et al (2013). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Nuclear Engineering and Design, 256, 75-86.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311517315039" target="_blank">Pizzocri D. et al (2018). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Journal of Nuclear Materials, 502, 323-330.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311519313868" target="_blank">Pizzocri D. et al (2020). SCIANTIX: A new open source multi-scale code for fission gas behaviour modelling designed for nuclear fuel performance codes. Journal of Nuclear Materials, 532, 152042.</a>
-
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311579900357" target="_blank">Reynolds A.B. and Burton C. (1979). Grain-boundary diffusion in uranium dioxide: The correlation between sintering and creep and a reinterpretation of creep mechanism. Journal of Nuclear Materials, 82, 22-25.</a>
-
 <a href="https://link.springer.com/article/10.1134/S0018151X07040177" target="_blank">Ronchi C. (2007). Thermophysical properties affecting safety and performance of nuclear fuel. High Temperatures, 45, 552-571.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311513012336" target="_blank">Talip Z. et al (2014). Journal of Nuclear Materials, 445, 117-127.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311571900754" target="_blank">Turnbull J.A. (1971). Journal of Nuclear Materials, 38, 203.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311571900754" target="_blank">Turnbull J.A. (1971). The re-solution of fission-gas atoms from bubbles during the irradiation of UO2 at an elevated temperature. Journal of Nuclear Materials, 38, 203.</a>
 
-<a href="https://inis.iaea.org/search/search.aspx?orig_q=RN:21003206" target="_blank">Turnbull J.A. et al (1988). IWGFPT-32, Preston, UK, Sep 18-22.</a>
+<a href="https://inis.iaea.org/search/search.aspx?orig_q=RN:21003206" target="_blank">Turnbull J.A. et al (1988). The diffusion coefficient for fission gas atoms in uranium dioxide. IWGFPT-32, Preston, UK, Sep 18-22.</a>
 
-<a href="https://www.nrc.gov/reading-rm/doc-collections/nuregs/contract/cr7003/index.html" target="_blank">Turnbull J.A., Beyer C.E. (2010). Background and Derivation of ANS-5.4 Standard Fission Product Release Model.</a>
-
-<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311512006526" target="_blank">Van Uffelen P. et al (2013). Journal of Nuclear Materials, 434, 287-290.</a>
-
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311583901769" target="_blank">White R.M. and Tucker P.G. (1983). Journal of Nuclear Materials, 118, 1-38.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311503004616" target="_blank">White R.M. (2004). Journal of Nuclear Materials, 325, 61-77.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S1738573321006148" target="_blank">Zullo G. et al (2022). Nuclear Engineering and Technology, 54, 1195-1205.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311523005111" target="_blank">Zullo G. et al (2023). Journal of Nuclear Materials, 587, 154744.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311524004070" target="_blank">Zullo G. et al (2024). Integral-scale validation of the SCIANTIX code for Light Water Reactor fuel rods Journal of Nuclear Materials, 601, 155305.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0029549324007027" target="_blank">Zullo G. et al (2024). Two-phase modelling for fission gas sweeping in restructuring nuclear oxide fuel. Nuclear Enginnering and Design, 429, 113602.</a>
 

--- a/references/references.md
+++ b/references/references.md
@@ -3,9 +3,9 @@
 
 ## SCIANTIX papers
 
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311523005111" target="_blank">Zullo G. et al (2023). The SCIANTIX code for fission gas behaviour: Status, upgrades, separate-effect validation, and future developments. Journal of Nuclear Materials, 587, 154744.</a>
-
 <a href="https://www.sciencedirect.com/science/article/pii/S0022311519313868" target="_blank">Pizzocri D. et al (2020). SCIANTIX: A new open source multi-scale code for fission gas behaviour modelling designed for nuclear fuel performance codes. Journal of Nuclear Materials, 532, 152042.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311523005111" target="_blank">Zullo G. et al (2023). The SCIANTIX code for fission gas behaviour: Status, upgrades, separate-effect validation, and future developments. Journal of Nuclear Materials, 587, 154744.</a>
 
 
 
@@ -21,15 +21,11 @@
 
 <a href="https://www.sciencedirect.com/science/article/pii/S0022311522001234" target="_blank">Barani T. et al (2022). Modeling high burnup structure in oxide fuels for application to fuel performance codes. Part II: Porosity evolution. Journal of Nuclear Materials, 563, 153627.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311583901769" target="_blank">White R.M. and Tucker P.G. (1983). A new fission-gas release model. Journal of Nuclear Materials, 118, 1-38.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0029549324007027" target="_blank">Zullo G. et al (2024). Two-phase modelling for fission gas sweeping in restructuring nuclear oxide fuel. Nuclear Enginnering and Design, 429, 113602.</a>
-
-<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029549312005754" target="_blank">Pastore G. et al (2013). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Nuclear Engineering and Design, 256, 75-86.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S0022311517315039" target="_blank">Pizzocri D. et al (2018). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Journal of Nuclear Materials, 502, 323-330.</a>
-
 <a href="https://www.sciencedirect.com/science/article/abs/pii/002231157390038X" target="_blank">Blackburn P.E. (1973). Oxygen pressures over fast breeder reactor fuel (I) A model for UO2+-x. Journal of Nuclear Materials, 46, 244-252.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S1738573320309451" target="_blank">Cechet A. et al (2021). A new burn-up module for application in fuel performance calculations targeting the helium production rate in (U,Pu)O2 for fast reactors. Nuclear Engineering and Technology, 53, 1893-1908.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S1738573320303557" target="_blank">Cognini L. et al (2021). Towards a physics-based description of intra-granular helium behaviour in oxide fuel for application in fuel performance codes. Nuclear Engineering and Technology, 53, 562-571.</a>
 
 <a href="https://www.researchgate.net/publication/272095903_Approaches_to_Modeling_of_High_Burn-up_Structure_and_Analysis_of_its_Effects_on_the_Behaviour_of_Light_Water_Reactor_Fuels_in_the_START-3_Fuel_Performance_Code" target="_blank">Khvostov G. et al (2005). Approaches to Modeling of High Burn-up Structure and Analysis of its Effects on the Behaviour of Light Water Reactor Fuels in the START-3 Fuel Performance Code. WRFPM-2005, Kyoto, Japan.</a>
 
@@ -37,15 +33,17 @@
 
 <a href="https://www.sciencedirect.com/science/article/pii/S0022311502008565" target="_blank">Lösönen P. (2002). Modelling intragranular fission gas release in irradiation of sintered LWR UO2 fuel. Journal of Nuclear Materials, 304, 29-49.</a>
 
+<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029549312005754" target="_blank">Pastore G. et al (2013). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Nuclear Engineering and Design, 256, 75-86.</a>
+
+<a href="https://www.sciencedirect.com/science/article/pii/S0022311517315039" target="_blank">Pizzocri D. et al (2018). Physics-based modelling of fission gas swelling and release in UO2 applied to integral fuel rod analysis. Journal of Nuclear Materials, 502, 323-330.</a>
+
 <a href="https://www.nrc.gov/reading-rm/doc-collections/nuregs/contract/cr7003/index.html" target="_blank">Turnbull J.A., Beyer C.E. (2010). Background and Derivation of ANS-5.4 Standard Fission Product Release Model.</a>
 
-<a href="https://www.sciencedirect.com/science/article/pii/S1738573320309451" target="_blank">Cechet A. et al (2021). A new burn-up module for application in fuel performance calculations targeting the helium production rate in (U,Pu)O2 for fast reactors. Nuclear Engineering and Technology, 53, 1893-1908.</a>
-
-<a href="https://www.sciencedirect.com/science/article/pii/S1738573320303557" target="_blank">Cognini L. et al (2021). Towards a physics-based description of intra-granular helium behaviour in oxide fuel for application in fuel performance codes. Nuclear Engineering and Technology, 53, 562-571.</a>
+<a href="https://www.sciencedirect.com/science/article/abs/pii/0022311583901769" target="_blank">White R.M. and Tucker P.G. (1983). A new fission-gas release model. Journal of Nuclear Materials, 118, 1-38.</a>
 
 <a href="https://www.sciencedirect.com/science/article/pii/S0022311503004616" target="_blank">White R.M. (2004). The development of grain-face porosity in irradiated oxide fuel. Journal of Nuclear Materials, 325, 61-77.</a>
 
-
+<a href="https://www.sciencedirect.com/science/article/pii/S0029549324007027" target="_blank">Zullo G. et al (2024). Two-phase modelling for fission gas sweeping in restructuring nuclear oxide fuel. Nuclear Enginnering and Design, 429, 113602.</a>
 
 
 
@@ -57,11 +55,9 @@
 
 <a href="https://www.sciencedirect.com/science/article/abs/pii/0022311570900632" target="_blank">Carter G. and Lay G.R. (1970). Surface-controlled oxidation-reduction of UO2. Journal of Nuclear Materials, 36, 77-86.</a>
 
-<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311512006526" target="_blank">Van Uffelen P. et al (2013). An experimental study of grain growth in mixed oxide samples with various microstructures and plutonium concentrations. Journal of Nuclear Materials, 434, 287-290.</a>
-
 <a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311513012336" target="_blank">Talip Z. et al (2014). Thermal diffusion of helium in 238Pu-doped UO2. Journal of Nuclear Materials, 445, 117-127.</a>
 
-
+<a href="https://www.sciencedirect.com/science/article/abs/pii/S0022311512006526" target="_blank">Van Uffelen P. et al (2013). An experimental study of grain growth in mixed oxide samples with various microstructures and plutonium concentrations. Journal of Nuclear Materials, 434, 287-290.</a>
 
 
 
@@ -74,10 +70,6 @@
 <a href="https://www.sciencedirect.com/science/article/abs/pii/0022311579900357" target="_blank">Reynolds A.B. and Burton C. (1979). Grain-boundary diffusion in uranium dioxide: The correlation between sintering and creep and a reinterpretation of creep mechanism. Journal of Nuclear Materials, 82, 22-25.</a>
 
 <a href="https://doi.org/10.1111/j.1151-2916.1969.tb11976.x" target="_blank">Bittel R. et al (1969). Steam Oxidation Kinetics and Oxygen Diffusion in UOz at High Temperatures. Journal of the American Ceramic Society, 52, 446-451.</a>
-
-
-
-
 
 
 


### PR DESCRIPTION
Hi,

I was wondering about changes to the `References` section of the documentation
- add titles of papers,
- sort them into groups by topic -- could it make orientation easier?

I still have to come up with better groups + sort some unsorted papers. 
I am proposing this PR already so that you can tell your opinion -- since this is just my personal opinion.

Thanks for any opinions here.