### PR TITLE
Revise grain boundary venting model documentation

### DIFF
--- a/docs/source/models/grain_boundary_venting.rst
+++ b/docs/source/models/grain_boundary_venting.rst
@@ -1,53 +1,55 @@
 Grain Boundary Venting
 ======================
 
-This model represents venting of gas from grain-boundary bubbles to the free
-volume (gap) once the grain boundary becomes sufficiently “open” (e.g. due to
-microcracking). The venting strength is expressed through a **venting
-probability**, which is then applied as a sink term to the grain-boundary gas
-inventories.
+This model represents venting of gas from grain-boundary to the free
+volume (gap). 
+This is modeled either via a fractional coverage-driven sigmoid representing the interconnection of bubbles or via correlations linked to the fuel's open porosity. The venting strength is expressed through a **venting probability**, applied as a sink term to the grain-boundary gas inventories.
 
 The implementation follows ``Simulation::GrainBoundaryVenting()``.
 
-Activation and option
----------------------
+Activation and options
+----------------------
 
 The model is enabled by:
 
 - ``iGrainBoundaryVenting`` (input option)
 
-If ``iGrainBoundaryVenting = 0``, the model returns immediately and no venting is
-applied.
+Options available:
+- ``0``: No venting, the model returns immediately.
+- ``1``: Sigmoid-based model, it represents bubble interconnection.
+- ``2``: Open porosity-based model (Claisse and Van Uffelen correlation).
+- ``3``: Open porosity-based model (under development).
 
 Inputs
 ------
 
 - ``iGrainBoundaryVenting`` (input option)
-- ``Intergranular fractional coverage``
-- ``Intergranular fractional intactness``
+- ``Intergranular fractional coverage`` for option 1
+- ``Intergranular fractional intactness`` for option 1
+- ``Fabrication porosity`` for options 2, 3
 - ``<Gas> at grain boundary`` for each gas system
 - ``Time step`` (physics variable)
 
 Outputs
 -------
 
-- ``P_vent`` (venting probability stored as a model parameter)
+- ``Intergranular venting probability, P_vent``
+- ``Open porosity`` for options 2, 3
 - Updated grain-boundary inventories (after applying the venting sink)
 
 Key variables
 -------------
 
 The model uses:
-
 - ``Intergranular fractional coverage``: initial fractional coverage at the grain boundary.
-- ``Intergranular fractional intactness``: measure of how “intact” the grain boundary is
-  (its increment and final value are used).
+- ``Intergranular fractional intactness``: measure of boundary integrity (increment and final value).
 - ``Intergranular vented fraction``: sigmoid-based fraction of vented boundary.
+- ``Open porosity``: fraction of interconnected porosity reaching the exterior.
 - ``Intergranular venting probability``: effective venting probability used in the sink term.
 - ``<Gas> at grain boundary`` for each gas system (Xe, Kr, He, radioactive gases, …).
 
-Sigmoid-based vented fraction
------------------------------
+Model Option 1: Sigmoid-based vented fraction
+---------------------------------------------
 
 For ``iGrainBoundaryVenting = 1``, a sigmoid function is used to compute the
 vented fraction. First, an internal sigmoid variable is defined as:
@@ -74,9 +76,6 @@ with constants (as in the code):
 - :math:`b = 10.0` (``span_parameter``),
 - :math:`c = 0.43` (``cent_parameter``).
 
-Venting probability
--------------------
-
 The effective venting probability is defined by mixing the intact and non-intact
 fractions:
 
@@ -89,24 +88,31 @@ where :math:`I^{n+1}` is the final value of ``Intergranular fractional intactnes
 
 Reference: Pizzocri et al., D6.4 (2020), H2020 Project INSPYRE.
 
-Application to grain-boundary gas inventories
----------------------------------------------
+Model Option 2: Open porosity-based (Claisse & Van Uffelen)
+----------------------------------------------------------
 
-The model stores:
-
-- ``P_vent`` as the single model parameter.
-
-Then, for **each** gas system, the grain-boundary inventory is updated by applying
-a sink term proportional to the current amount at the grain boundary:
+For ``iGrainBoundaryVenting = 2``, the probability depends on the open porosity $p_{\mathrm{open}}$:
 
 .. math::
 
-   C_{\mathrm{gb}}^{n+1} =
-   C_{\mathrm{gb}}^{n} - P_{\mathrm{vent}}\,C_{\mathrm{gb}}^{n}\,\Delta t
+    P_{\mathrm{vent}} = 1.54 \sqrt{p_{\mathrm{open}}}
 
-In the implementation this is done through:
+The open porosity is calculated from ``Fabrication porosity`` ($p_{\mathrm{fab}}$) as:
 
-- ``solver.Integrator( <Gas> at grain boundary , -P_vent , <Gas> at grain boundary increment )``
+- If $p_{\mathrm{fab}} < 0.050$: $p_{\mathrm{open}} = p_{\mathrm{fab}} / 20$
+- If $0.050 \leq p_{\mathrm{fab}} \leq 0.058$: $p_{\mathrm{open}} = 3.10 \, p_{\mathrm{fab}} - 0.1525$
+- If $p_{\mathrm{fab}} > 0.058$: $p_{\mathrm{open}} = p_{\mathrm{fab}} / 2.1 - 3.2 \cdot 10^{-4}$
 
-Finally, the grain-boundary variable is reset for the next step using
-``resetValue()``.
+Reference: Claisse and Van Uffelen, JNM, 466 (2015).
+
+Application to grain-boundary gas inventories
+---------------------------------------------
+
+For **each** gas system, the inventory is updated by a sink term:
+
+.. math::
+
+    C_{\mathrm{gb}}^{n+1} = C_{\mathrm{gb}}^{n} - P_{\mathrm{vent}}\,C_{\mathrm{gb}}^{n}\,\Delta t
+
+Implemented as:
+``solver.Integrator( <Gas> at grain boundary, -P_vent, <Gas> at grain boundary increment )``


### PR DESCRIPTION
Updated the grain boundary venting model documentation to clarify venting mechanisms and options. Added details on sigmoid and open porosity-based models, including input and output specifications.